### PR TITLE
Add spacy as dependency

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -36,6 +36,7 @@ mkShell {
     webdriver-manager
     jsonschema
     tweepy
+    spacy
 
     ## Dev
     coverage


### PR DESCRIPTION
Hi!

It appears AutoGPT requires Spacy to run.

Ref: https://github.com/Significant-Gravitas/Auto-GPT/blob/1e3bcc3f8bf82366122b598c003f794ffbdefd89/requirements.txt#L23