### PR TITLE
Add spacy en model for browsing web pages

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -38,6 +38,7 @@ mkShell {
     tweepy
     click
     spacy
+    spacy_models.en_core_web_sm
 
     ## Dev
     coverage


### PR DESCRIPTION
The spacy language model is missing and causing a runtime error when autogpt tries to browse a webpage. This adds it to builtin deps.