### PR TITLE
chore: add `.envrc`  file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake


### PR DESCRIPTION
This PR:

- Add missing `.envrc` file to match `direnv` documentation in README file.